### PR TITLE
Fix URL opening on Windows

### DIFF
--- a/autoload/link/utils.vim
+++ b/autoload/link/utils.vim
@@ -59,7 +59,7 @@ function! link#utils#GetOpenCommand(os) abort
   elseif a:os ==? 'Linux'
     return 'xdg-open'
   elseif a:os ==? 'Windows'
-    return 'start'
+    return 'start ""'
   else
     throw 'Unknown operating system'
   endif


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/076c6fa8-fad4-4f75-9dbb-d6d66db1a787)
`start https://github.com/qadzek/link.vim` should be `start "" https://github.com/qadzek/link.vim`